### PR TITLE
Updates to getCustomerPaymentReport and fixing IDs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,5 +15,10 @@
         }
       },
     "minimum-stability": "stable",
-    "require": {}
+    "require": {
+        "symfony/polyfill-php80": "^1.0.0",
+        "symfony/polyfill-php81": "^1.0.0",
+        "symfony/polyfill-php82": "^1.0.0",
+        "symfony/polyfill-php83": "^1.0.0"
+    }
 }

--- a/src/API.php
+++ b/src/API.php
@@ -207,7 +207,7 @@ class API extends \Infira\MeritAktiva\General
 	 */
 	public function getSalesInvoiceByID(string $GUID, string $apiVersion = self::API_V1): APIResult
 	{
-		return new APIResult($this->send("$apiVersion/getinvoice", ['id' => $GUID]));
+		return new APIResult($this->send("$apiVersion/getinvoice", ['Id' => $GUID]));
 	}
 
 	/**
@@ -260,7 +260,7 @@ class API extends \Infira\MeritAktiva\General
 	 */
 	public function getPurchaseInvoiceByID(string $GUID, string $apiVersion = self::API_V1): APIResult
 	{
-		return new APIResult($this->send("$apiVersion/getpurchorder", ['id' => $GUID]));
+		return new APIResult($this->send("$apiVersion/getpurchorder", ['Id' => $GUID]));
 	}
 
 	/**
@@ -329,7 +329,7 @@ class API extends \Infira\MeritAktiva\General
 	 */
 	public function deleteSalesInvoiceByID(string $GUID): APIResult
 	{
-		return new APIResult($this->send("v1/deleteinvoice", ['id' => $GUID]));
+		return new APIResult($this->send("v1/deleteinvoice", ['Id' => $GUID]));
 	}
 
 	/**

--- a/src/API.php
+++ b/src/API.php
@@ -47,8 +47,7 @@ class API extends \Infira\MeritAktiva\General
 	private $lastRequestData = "";
 	private $lastRequestUrl  = "";
 	private $url             = "";
-	private $debug           = false;
-	private $jsonCheckError  = true; // Throws exception when json decoding fails
+	private $debug           = FALSE;
 
 	public function __construct($apiID, $apiKey, $country = 'ee', $vatPercent = 20)
 	{
@@ -74,10 +73,6 @@ class API extends \Infira\MeritAktiva\General
 		$this->debug = $bool;
 	}
 
-    public function setJsonCheckError(bool $jsonCheckError): void
-    {
-        $this->jsonCheckError = $jsonCheckError;
-    }
 
 	public function getLastRequestData()
 	{
@@ -139,7 +134,7 @@ class API extends \Infira\MeritAktiva\General
 
 		if ($status != 200) {
 			$error = "Error: call to URL $url <br>STATUS: $status<br>CURL_ERROR: " . curl_error($curl) . "<br> CURL_ERRNO: " . curl_errno($curl);
-			$error .= '<br><br>API SAYS:' . mertiApiDump($this->jsonDecode($curlResponse));
+			$error .= '<br><br>API SAYS:' . mertiApiDump($this->jsonDecode($curlResponse, TRUE));
 
 			return $error;
 		}
@@ -148,25 +143,20 @@ class API extends \Infira\MeritAktiva\General
         return $this->jsonDecode($curlResponse);
 	}
 
-    private function jsonDecode($json)
-    {
-        $decodeFlags = 0;
-        if ($this->jsonCheckError) {
-            $decodeFlags = JSON_THROW_ON_ERROR;
-        }
-        $json = stripslashes($json);
-        if (substr($json, 0, 1) == '"' and substr($json, -1) == '"') {
-            $data = json_decode(substr($json, 1, -1), null, 512, $decodeFlags);
-        } else {
-            $data = json_decode($json, null, 512, $decodeFlags);
-        }
+	private function jsonDecode($json, $checkError = FALSE)
+	{
+		$json = stripslashes($json);
+		if (substr($json, 0, 1) == '"' and substr($json, -1) == '"') {
+			$data = json_decode(substr($json, 1, -1));
+		} else {
+			$data = json_decode($json);
+		}
+		if (json_last_error() and $checkError) {
+			return $json;
+		}
 
-        if (json_last_error() && $this->jsonCheckError) {
-            return null;
-        }
-
-        return $data;
-    }
+		return $data;
+	}
 
 	private static function toUTF8($string)
 	{

--- a/src/API.php
+++ b/src/API.php
@@ -458,6 +458,38 @@ class API extends \Infira\MeritAktiva\General
         return new APIResult($data);
     }
 
+    /**
+     * @param string $Id4More
+     * @return APIResult
+     * @see https://api.merit.ee/connecting-robots/reference-manual/reports/customer-payment-report/
+     */
+    public function getMoreData(string $Id4More)
+    {
+        // Strip slashes malforms the json data here
+        $data = $this->send("v2/getmoredata", ['Id4More' => $Id4More], false);
+
+        // Try to decode subdata that is json string
+        if (is_object($data)) {
+            foreach ($data as $key => $value) {
+                if ($this->looksLikeJson($value)) {
+                    $data->{$key} = $this->jsonDecode($value);
+                } else {
+                    $data->{$key} = $value;
+                }
+            }
+        }
+
+        // Parse dates
+        foreach ($data->Data as $dataRow) {
+            preg_match(':(\d+):i', $dataRow->DocDate ?? '', $parts);
+            $dataRow->DocDate = (int)$parts[1];
+            preg_match(':(\d+):i', $dataRow->DueDate ?? '', $parts);
+            $dataRow->DueDate = (int)$parts[1];
+        }
+
+        return new APIResult($data);
+    }
+
 	/*************** Endpoint wrappers ***************/
     /**
      * Get customer list


### PR DESCRIPTION
There's one unmerged update from 2023, when I updated getCustomerPaymentReport to improve JSON data parsing.

Now, 2025, there has been some change in Merit API, and some queries with lowercase 'id' have started to fail. Updated those to 'Id' as the Merit documentation states.

Forget the "Throws exception when json decoding fail.." commits. That was non working experiment and has been reverted as you see.