### PR TITLE
fix: use UTC time rather than local and request binary data from hash…

### DIFF
--- a/src/API.php
+++ b/src/API.php
@@ -86,7 +86,7 @@ class API extends \Infira\MeritAktiva\General
 
 	private function send($endPoint, $payload = null, bool $stripSlashes = true)
 	{
-		$timestamp = date("YmdHis");
+		$timestamp = gmdate("YmdHis");
 		$urlParams = "";
 		$json      = "";
 		if ($payload) {
@@ -97,7 +97,7 @@ class API extends \Infira\MeritAktiva\General
 		}
 
 		$dataString            = $this->apiID . $timestamp . $json;
-		$hash                  = hash_hmac("sha256", $dataString, $this->apiKey);
+		$hash                  = hash_hmac("sha256", $dataString, $this->apiKey, true);
 		$signature             = base64_encode($hash);
 		$url                   = sprintf(
 			'%s%s?ApiId=%s&timestamp=%s&signature=%s' . $urlParams,


### PR DESCRIPTION
Switched timestamp from `date` to `gmdate` to ensure UTC timestamp, if server does not use UTC time.
Added force raw output parameter to `hash_hmac` call, otherwise the signature is not accepted after base64 encoding.