### PR TITLE
Remove deprecated curl_close() call in API::send()

### DIFF
--- a/src/API.php
+++ b/src/API.php
@@ -138,7 +138,6 @@ class API extends \Infira\MeritAktiva\General
 
 			return $error;
 		}
-        curl_close($curl);
 
         return $this->jsonDecode($curlResponse, false, $stripSlashes);
 	}

--- a/tests/CurlCloseTest.php
+++ b/tests/CurlCloseTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Infira\MeritAktiva\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Infira\MeritAktiva\API;
+
+/**
+ * Guards against re-introducing curl_close() in API::send().
+ *
+ * curl_close() has been a no-op since PHP 8.0 and is deprecated as of PHP 8.5.
+ * When the host project routes E_DEPRECATED through an exception handler (e.g.
+ * Yii2), the call throws *after* the HTTP request already succeeded, so callers
+ * see a request fail even though it went through. The handle is freed
+ * automatically when it goes out of scope, so the call is simply removed.
+ */
+class CurlCloseTest extends TestCase
+{
+    public function testSendDoesNotCallDeprecatedCurlClose(): void
+    {
+        $method = new \ReflectionMethod(API::class, 'send');
+        $source = implode('', array_slice(
+            file($method->getFileName()),
+            $method->getStartLine() - 1,
+            $method->getEndLine() - $method->getStartLine() + 1
+        ));
+
+        $this->assertStringNotContainsString(
+            'curl_close',
+            $source,
+            'API::send() must not call curl_close() (no-op since PHP 8.0, deprecated in 8.5).'
+        );
+    }
+}


### PR DESCRIPTION
curl_close() has been a no-op since PHP 8.0 and is deprecated as of PHP 8.5. When the host project routes E_DEPRECATED through an exception handler (e.g. Yii2), it is thrown *after* the request already succeeded, so callers see the request fail even though it went through. The curl handle is freed automatically when it leaves scope, so the call is simply removed. Safe across the supported range (PHP >= 7.4).